### PR TITLE
fix PDO event timer processing

### DIFF
--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -150,7 +150,7 @@ fn should_trigger_pdo(is_sync: bool, event: NodeEvent, transmission_type: u32, e
             // info!("xfguo: transmit_pdo_messages 1.1.2, count = {}, tt = {}", count, transmission_type);
             return false;
         }
-        if event_times == 0 || count % event_times != 0 {
+        if event_times != 0 && count % event_times != 0 {
             // info!("xfguo: transmit_pdo_messages 1.1.3, count = {}, event_timer = {}", count, event_times);
             return false;
         }


### PR DESCRIPTION
Following spec, event timer is in effect when the value is not 0. That means when the value is zero, it may be ignored completely hence processing may continue to trigger PDO processing.