### PR TITLE
enhance ignorance of access control to more functions

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -144,11 +144,11 @@ impl<CAN: Can> Node<CAN> where CAN::Frame: Frame + Debug {
             for j in 0..4 {
                 let idx = i + j;
 
-                if let Ok(var) = self.object_directory.get_variable(idx, 0) {
+                if let Ok(var) = self.object_directory.get_variable(idx, 0, false) {
                     let var_clone = var.clone();
                     let len: u8 = var_clone.default_value().to();
                     for k in 1..=len {
-                        if let Ok(sub_var) = self.object_directory.get_variable(idx, k) {
+                        if let Ok(sub_var) = self.object_directory.get_variable(idx, k, false) {
                             let sub_var_clone = sub_var.clone();
                             self.update(&sub_var_clone)?;
                         }
@@ -160,7 +160,7 @@ impl<CAN: Can> Node<CAN> where CAN::Frame: Frame + Debug {
                 let mut k = 0u8;
 
                 while k <= len {
-                    if let Ok(var) = self.object_directory.get_variable(idx, k) {
+                    if let Ok(var) = self.object_directory.get_variable(idx, k, false) {
                         let var_clone = var.clone();
                         self.update(&var_clone)?;
                         if k == 0 { len = var_clone.default_value().to(); }

--- a/src/object_directory.rs
+++ b/src/object_directory.rs
@@ -270,11 +270,11 @@ impl ObjectDirectory {
         }
     }
 
-    pub fn set_value_with_fitting_size(&mut self, index: u16, sub_index: u8, data: &[u8]) {
+    pub fn set_value_with_fitting_size(&mut self, index: u16, sub_index: u8, data: &[u8], ignore_access_check: bool) {
         match self.get_mut_variable(index, sub_index) {
             Err(_) => {}
             Ok(var) => {
-                if !var.access_type.is_writable() {
+                if !ignore_access_check && !var.access_type.is_writable() {
                     return;
                 }
                 if var.data_type.size() > data.len() {
@@ -311,10 +311,10 @@ impl ObjectDirectory {
         }
     }
 
-    pub fn get_variable(&mut self, index: u16, sub_index: u8) -> Result<&Variable, ErrorCode> {
+    pub fn get_variable(&mut self, index: u16, sub_index: u8, ignore_access_check: bool) -> Result<&Variable, ErrorCode> {
         match self.get_mut_variable(index, sub_index) {
             Ok(var) => {
-                if !var.access_type.is_readable() {
+                if !ignore_access_check && !var.access_type.is_readable() {
                     return Err(make_abort_error(AttemptToReadWriteOnlyObject, "".to_string()));
                 }
                 Ok(var)

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -186,7 +186,7 @@ impl<CAN: Can> Node<CAN> where CAN::Frame: Frame + Debug {
 
             for (idx, &(i, si, _)) in pdo.mappings.iter().enumerate().take(pdo.num_of_map_objs as usize) {
                 let (data, _) = unpacked_data[idx];
-                self.object_directory.set_value_with_fitting_size(i, si, &data.to_le_bytes());
+                self.object_directory.set_value_with_fitting_size(i, si, &data.to_le_bytes(), true);
             }
 
             pdo.clear_cached_data();
@@ -195,7 +195,7 @@ impl<CAN: Can> Node<CAN> where CAN::Frame: Frame + Debug {
 
     fn validate_pdo_mappings(&mut self, pdo: &PdoObject, index: u16) -> Result<(), ErrorCode> {
         for si in (1..=pdo.num_of_map_objs as usize).rev() {
-            self.object_directory.get_variable(index, si as u8)
+            self.object_directory.get_variable(index, si as u8, false)
                 .map_err(|_| make_abort_error(AbortCode::ObjectCannotBeMappedToPDO, "".to_string()))?;
         }
         Ok(())
@@ -265,7 +265,7 @@ impl<CAN: Can> Node<CAN> where CAN::Frame: Frame + Debug {
                                 -> Result<CAN::Frame, ErrorCode> {
         let mut data_pairs = Vec::new();
         for (idx, sub_idx, bits) in mappings.iter().take(num_of_map_objs as usize) {
-            let variable = self.object_directory.get_variable(*idx, *sub_idx)
+            let variable = self.object_directory.get_variable(*idx, *sub_idx, true)
                 .map_err(|_| ErrorCode::VariableNotFound { index: *idx, sub_index: *sub_idx })?;
 
             let data = vec_to_u64(variable.default_value().data());

--- a/src/sdo_server.rs
+++ b/src/sdo_server.rs
@@ -123,7 +123,7 @@ impl<CAN: Can> Node<CAN> where CAN::Frame: Frame + Debug {
     }
 
     fn initiate_upload(&mut self, index: u16, sub_index: u8) -> Result<Option<CAN::Frame>, ErrorCode> {
-        let var = self.object_directory.get_variable(index, sub_index)?;
+        let var = self.object_directory.get_variable(index, sub_index, false)?;
         let data = var.default_value().data();
 
         if data.is_empty() {
@@ -328,7 +328,7 @@ impl<CAN: Can> Node<CAN> where CAN::Frame: Frame + Debug {
         self.block_size = blk_size;
         self.reserved_index = index;
         self.reserved_sub_index = sub_index;
-        let var = self.object_directory.get_variable(index, sub_index)?;
+        let var = self.object_directory.get_variable(index, sub_index, false)?;
         self.read_buf = Some(var.default_value().data().clone());
         self.read_buf_index = 0;
 
@@ -422,7 +422,7 @@ impl<CAN: Can> Node<CAN> where CAN::Frame: Frame + Debug {
         let dest_sub_index = data[1];
 
         // Retrieve variable and validate if it can be mapped to PDO.
-        let var = self.object_directory.get_variable(dest_index, dest_sub_index)?;
+        let var = self.object_directory.get_variable(dest_index, dest_sub_index, false)?;
         if !var.pdo_mappable() || (index < 0x1800 && !var.access_type().is_writable()) {
             return Err(make_abort_error(ObjectCannotBeMappedToPDO, "".to_string()));
         }


### PR DESCRIPTION
To get T/R-PDO working we need to enhance ignorance of access control rules to also get_variable and set_value_with_fitting_size functions. This issue solves wrong usage of SDO's access control properties for T/RPDO.